### PR TITLE
Fix Quickstart your SSH protection Recipe links

### DIFF
--- a/quickstart-ssh-protection.yaml
+++ b/quickstart-ssh-protection.yaml
@@ -170,7 +170,7 @@ data:
 
         In this step, you will define how your users should authenticate to your namespace.
 
-        _Note: Read more about [configuring OIDC for Aporeto](.Aporeto.junonUrl/docs/main/guides/oidc/oidc-access-control-plane/)_
+        _Note: Read more about [configuring OIDC for Aporeto](.Aporeto.junonUrl/saas/setup/idp/)_
 
       parameters:
       - key: realm


### PR DESCRIPTION
Fix for the documentation links for "Quickstart your SSH protection" recipe to point to the corresponding newer doc pages.