### PR TITLE
Doc updates and network policy tag update

### DIFF
--- a/quickstart-create-admin-access.yaml
+++ b/quickstart-create-admin-access.yaml
@@ -76,7 +76,7 @@ data:
           - "@auth:role=namespace.editor"
         {{- else }}
         apiauthorizationpolicies:
-        - name: "Adminitrators"
+        - name: "Administrators"
           description: "Define administrators access via Google"
           propagate: true
           subject:
@@ -96,12 +96,12 @@ data:
 
         In this step, you will define which one you want to use to access your namespace.
 
-        _Note: Read more about [configuring OIDC for Aporeto](.Aporeto.junonUrl/docs/main/guides/oidc/oidc-access-control-plane/)_
+        _Note: Read more about [configuring OIDC for Aporeto](.Aporeto.junonUrl/saas/setup/idp/)_
 
       parameters:
       - key: realm
         name: Identity Provider
-        description: Which identity provider would you like to use ?
+        description: Which identity provider would you like to use?
         type: Enum
         defaultValue: google
         allowedChoices:

--- a/quickstart-linux.yaml
+++ b/quickstart-linux.yaml
@@ -39,7 +39,7 @@ data:
 
         _(See all Namespaces from the left menu under "Namespace Settings")_
 
-        2. Define the protection of your VM and we will defined some **Host Services** for you.
+        2. Define the protection of your VM and we will define some **Host Services** for you.
 
         _(See all Host Services from the left menu under "Node")_
 
@@ -255,7 +255,7 @@ data:
         - name: Namespace
           description: |-
             Define where the data will be created.
-            You can either choose to use the current namespace **.Aporeto.junonUrl** or create a new one.
+            You can either choose to use the current namespace or create a new one.
 
             Having a separate namespace allows you to give permissions to other users to access that specific namespace.
 

--- a/quickstart-ssh-protection.yaml
+++ b/quickstart-ssh-protection.yaml
@@ -146,11 +146,11 @@ data:
           subject:
           - - "$identity=processingunit"
             - "$type=SSHSession"
-          - - "$identity=externalnetwork"
+          - - "ext:net=internet"
           object:
           - - "$identity=processingunit"
             - "$type=SSHSession"
-          - - "$identity=externalnetwork"
+          - - "ext:net=internet"
 
         auditprofilemappingpolicies:
         - name: "Enforcers collect execve commands"


### PR DESCRIPTION
Some documentation updates to the recipes and changed the network access policy in SSH protection recipe to use the associated tag for the external network instead of the identity tag.