### PR TITLE
Automatically deploy recipe to force workspace/platform/app organization

### DIFF
--- a/account-organizational-metadata.yaml
+++ b/account-organizational-metadata.yaml
@@ -87,7 +87,7 @@ data:
             api.Create('import', content, namespace);
 
             // TODO: Do not automatically deploy the recipe for now.
-            return deployRecipeWithLabelFilter(api, namespace, 'label == "recipe:namespace-organizational-metadata"')
+            // return deployRecipeWithLabelFilter(api, namespace, 'label == "recipe:namespace-organizational-metadata"')
           }
 
           function deployRecipeWithLabelFilter(api, namespace, filter) {

--- a/account-organizational-metadata.yaml
+++ b/account-organizational-metadata.yaml
@@ -16,6 +16,7 @@ data:
       description: "Triggered by the hook called account-organizational-metadata-hook"
       trigger: Webhook
       protected: true
+      mode: Pre
       actions:
         - |
           function organizationalMetadataForNamespace(namespace) {
@@ -62,6 +63,78 @@ data:
               }
 
           }
+    - name: add-namespace-organizational-metadata
+      description: "Triggered after a namespace is created to install a recipe"
+      trigger: Event
+      protected: true
+      mode: Post
+      events:
+        namespace:
+          - create
+      entitlements:
+        import:
+          - create
+        recipe:
+          - create
+      condition: |-
+        function when(api, params) {
+            return { continue: true, payload: { namespace: params.eventPayload.entity } };
+        }
+      actions:
+        - |
+          function then(api, params, payload) {
+
+            var content = {
+              data: {
+                "APIVersion": 1,
+                "label": "recipe:namespace-organizational-metadata",
+                "data": {
+                  "recipes": [
+                    {
+                      "name": "Namespace organization metadata",
+                      "description": "Controls organizational metadata of your namespaces",
+                      "label": "recipe:namespace-organizational-metadata",
+                      "propagate": false,
+                      "deploymentMode": "Unique",
+                      "metadata": [
+                        "@aporeto:author=aporeto"
+                      ],
+                      "associatedTags": null,
+                      "targetIdentities": [
+                        "automation",
+                        "hookpolicy"
+                      ],
+                      "longDescription": "\nA metadata is a \"key=value\" pair, where value is the name of your namespace.\n\nThis workflow allows to define the keys of your organizational metadata that are used to represent\nyour namespace hiearchy.\n\nBy default, we suggest to consider the following keys:\n\n1. workspace\n2. platform\n3. app\n\nThese metadata will be propagated to your processing units, enforcers, external networks and can then be used\nin your policies rules.",
+                      "template": "{{`\nAPIVersion: 1\nlabel: \"recipe:namespace-organizational-metadata\"\ndata:\n  hookpolicies:\n    - name: \"namespace-organizational-metadata-hook\"\n      description: \"Triggers automation called namespace-organizational-metadata\"\n      endpointType: Automation\n      propagate: true\n      protected: true\n      subject:\n        - - \"$identity=namespace\"\n      selectors:\n        - - \"$identity=automation\"\n          - \"$name=namespace-organizational-metadata\"\n  automations:\n    - name: namespace-organizational-metadata\n      description: \"Triggered by the hook called namespace-organizational-metadata-hook\"\n      trigger: Webhook\n      propagate: true\n      protected: true\n      actions:\n        - |\n          function organizationalMetadataForNamespace(namespace) {\n\n            {{- if .Values.keys }}\n            keys = [{{range $index, $key := .Values.keys }}{{ if ne $index 0}}, {{end}}\"{{ $key }}\"{{ end }}];\n            {{- else }}\n            keys = [];\n            {{- end}}\n\n            parents = namespace.namespace.split(\"/\");\n            parents.shift()\n\n            if (!parents || parents.length == 0) {\n              return [];\n            }\n\n            // Root namespace case not handled in this workflow.\n            if (parents[0] === \"\") {\n              return [];\n            }\n\n            idx = parents.length - 1;\n            if (idx >= keys.length) {\n              return [];\n            }\n\n            k = keys[idx];\n            if (k === \"\") {\n              return [];\n            }\n\n            return [\"@org:\" + k + \"=\" + namespace.name];\n          }\n          /**\n          * This function will be executed when the automation condition is met:\n          * @param {object} api - api manipulator that allows CRUD operations.\n          * @param {object} params - the parameters configured in the automation.\n          * @param {object} payload - Payload returned by the condition.\n          */\n          function then(api, params) {\n\n              var triggerPayload = JSON.parse(params.triggerPayload);\n              var namespace = triggerPayload.input;\n\n              if (triggerPayload.operation !== \"create\" || !namespace.name) {\n                triggerPayload.output = triggerPayload.input;\n                return {\n                  \"statusCode\": 200,\n                  \"body\": JSON.stringify(triggerPayload),\n                }\n              }\n\n              namespace.organizationalMetadata = organizationalMetadataForNamespace(namespace);\n\n              // populates the output field of the remote processor model with our modifications\n              triggerPayload.output = namespace;\n\n              return {\n                  \"statusCode\": 200,\n                  \"body\": JSON.stringify(triggerPayload),\n              }\n\n          }\nidentities:\n  - hookpolicy\n  - automation\n`}}",
+                      "steps": [
+                        {
+                          "name": "Structure",
+                          "description": "Provides the sorted list of key that describes best your namespace hiearchy.",
+                          "parameters": [
+                            {
+                              "key": "keys",
+                              "name": "Keys",
+                              "description": "Sorted list of keys",
+                              "type": "StringSlice",
+                              "defaultValue": [
+                                "workspace",
+                                "platform",
+                                "app"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+
+            return api.Create('import', content, payload.namespace.name);
+
+          }
+
 identities:
   - hookpolicy
   - automation

--- a/account-organizational-metadata.yaml
+++ b/account-organizational-metadata.yaml
@@ -15,6 +15,17 @@ data:
           - create
         recipe:
           - create
+          - retrieve-many
+        rendertemplate:
+          - create
+        importreference:
+          - create
+        hookpolicy:
+          - create
+          - retrieve-many
+        automation:
+          - create
+          - retrieve-many
       condition: |-
         function when(api, params) {
             return { continue: true, payload: { namespace: params.eventPayload.entity } };
@@ -70,8 +81,45 @@ data:
               }
             }
 
-            return api.Create('import', content, payload.namespace.name);
+            var namespace = payload.namespace.name;
 
+            // Import recipe
+            api.Create('import', content, namespace);
+
+            // TODO: Do not automatically deploy the recipe for now.
+            return deployRecipeWithLabelFilter(api, namespace, 'label == "recipe:namespace-organizational-metadata"')
+          }
+
+          function deployRecipeWithLabelFilter(api, namespace, filter) {
+
+            // Find recipe
+            var recipes = api.RetrieveMany('recipe', namespace, filter)
+
+            if (recipes.length !== 1) {
+              console.error("could not find recipe. Skipping");
+              return;
+            }
+
+            var recipe = recipes[0];
+
+            // Render template with default values
+            var render = api.Create('rendertemplate', {
+              parameters: {
+                keys: ["workspace", "platform", "app"]
+              },
+              template: recipe.template
+            }, namespace);
+
+
+            // Transform the rendered YAML into an gaia.Export object so it can be used
+            // in the next call.
+            data = aporeto.identityFromYaml('export', render.output);
+
+            // Deploy recipe
+            return api.Create('importreference', {
+              name: "Namespace organization metadata",
+              data: data
+            }, namespace, null, 'recipe', recipe.ID);
           }
 
 identities:

--- a/account-organizational-metadata.yaml
+++ b/account-organizational-metadata.yaml
@@ -1,69 +1,8 @@
 APIVersion: 1
 label: "recipe:account-organizational-metadata"
 data:
-  hookpolicies:
-    - name: "account-organizational-metadata-hook"
-      description: "Triggers automation called account-organizational-metadata"
-      endpointType: Automation
-      protected: true
-      subject:
-        - - "$identity=namespace"
-      selectors:
-        - - "$identity=automation"
-          - "$name=account-organizational-metadata"
   automations:
-    - name: account-organizational-metadata
-      description: "Triggered by the hook called account-organizational-metadata-hook"
-      trigger: Webhook
-      protected: true
-      mode: Pre
-      actions:
-        - |
-          function organizationalMetadataForNamespace(namespace) {
-
-            accountKey = {{ .Values.accountKey | default "account" | quote}}
-
-            if (namespace.namespace !== "/") {
-              return [];
-            }
-
-            if (accountKey === "") {
-              return [];
-            }
-
-            return ["@org:" + accountKey + "=" + namespace.name];
-          }
-          /**
-          * This function will be executed when the automation condition is met:
-          * @param {object} api - api manipulator that allows CRUD operations.
-          * @param {object} params - the parameters configured in the automation.
-          * @param {object} payload - Payload returned by the condition.
-          */
-          function then(api, params) {
-
-              var triggerPayload = JSON.parse(params.triggerPayload);
-              var namespace = triggerPayload.input;
-
-              if (triggerPayload.operation !== "create" || !namespace.name) {
-                triggerPayload.output = triggerPayload.input;
-                return {
-                  "statusCode": 200,
-                  "body": JSON.stringify(triggerPayload),
-                }
-              }
-
-              namespace.organizationalMetadata = organizationalMetadataForNamespace(namespace);
-
-              // populates the output field of the remote processor model with our modifications
-              triggerPayload.output = namespace;
-
-              return {
-                  "statusCode": 200,
-                  "body": JSON.stringify(triggerPayload),
-              }
-
-          }
-    - name: add-namespace-organizational-metadata
+    - name: add-namespace-organizational-recipe
       description: "Triggered after a namespace is created to install a recipe"
       trigger: Event
       protected: true

--- a/namespace-organizational-metadata.yaml
+++ b/namespace-organizational-metadata.yaml
@@ -54,6 +54,7 @@ data:
             trigger: Webhook
             propagate: true
             protected: true
+            mode: Pre
             actions:
               - |
                 function organizationalMetadataForNamespace(namespace) {

--- a/namespace-organizational-metadata.yaml
+++ b/namespace-organizational-metadata.yaml
@@ -41,7 +41,6 @@ data:
           - name: "namespace-organizational-metadata-hook"
             description: "Triggers automation called namespace-organizational-metadata"
             endpointType: Automation
-            propagate: true
             protected: true
             subject:
               - - "$identity=namespace"


### PR DESCRIPTION
This is in preparation of July release.

#### What does this file do?
The file `account-organiational-metadata.yaml` is imported in root namespace.

1. It creates adds an automation in the root namespace.
2. This automation is triggered when a new account namespace is created.
3. When the automation is triggered, it imports a new recipe in the newly created namespace. The recipe is the equivalent of `namespace-organizational-metadata.yaml` file.
4. After the recipe is imported, it is automatically deployed

#### What does the recipe imported do?

This recipe imported in the account namespace will create an automation that, again, will be triggered whenever a namespace is created. Every time a namespace is created under the account namespace, it will get an organizational tag. By default, it is set to workspace/platform/app.

#### Advantage of a recipe

The customer will be able to delete this recipe if needed. 
It has been said clearly that if the customer wants to change the tags of the recipe. The customer can undeploy the recipe and redeploy it with new keywords. However, this should be done prior creating namespaces and deploying a production environment.

#### Blocker

For now, we can't do step 4 as an automation cannot create another automation. So this PR is currently not working.

