### PR TITLE
Update: Move recipes to v2 external network model (#25)

### DIFF
--- a/networking-allow-dns.yaml
+++ b/networking-allow-dns.yaml
@@ -38,10 +38,8 @@ data:
           - "ext:net=all-dns"
           entries:
           - "0.0.0.0/0"
-          protocols:
-          - udp
-          ports:
-          - "53"
+          servicePorts:
+          - "udp/53"
       `}}
     steps:
     - name: Propagation

--- a/networking-simple-secure-app.yaml
+++ b/networking-simple-secure-app.yaml
@@ -120,17 +120,26 @@ data:
             - "{{ $shortname }}:ext:net=internet"
             entries:
             - "0.0.0.0/0"
-            protocols:
-            {{- if or (eq .Values.publicIncomingAccessMode "TCP") (eq .Values.publicIncomingAccessMode "any") }}
-            - "tcp"
+            servicePorts:
+            {{- if eq .Values.publicIncomingAccessMode "any" }}
+            - "any"
             {{- end }}
-            {{- if or (eq .Values.publicIncomingAccessMode "UDP") (eq .Values.publicIncomingAccessMode "any") }}
-            - "udp"
-            {{- end }}
+            {{- if or (eq .Values.publicIncomingAccessMode "TCP") }}
             {{- if .Values.publicIncomingAccessPorts }}
-            ports:
             {{- range $idx, $port := .Values.publicIncomingAccessPorts }}
-            - "{{ $port }}"
+            - "tcp/{{ $port }}"
+            {{- end }}
+            {{- else }}
+            - "tcp/1:65535"
+            {{- end }}
+            {{- end }}
+            {{- if or (eq .Values.publicIncomingAccessMode "UDP") }}
+            {{- if .Values.publicIncomingAccessPorts }}
+            {{- range $idx, $port := .Values.publicIncomingAccessPorts }}
+            - "udp/{{ $port }}"
+            {{- end }}
+            {{- else }}
+            - "udp/1:65535"
             {{- end }}
             {{- end }}
           {{- end }}
@@ -141,8 +150,8 @@ data:
             - "{{ $shortname }}:ext:net=public:tcp"
             entries:
             - "0.0.0.0/0"
-            protocols:
-            - "tcp"
+            servicePorts:
+            - "tcp/1:65535"
           {{- end }}
           {{- if or (eq .Values.publicOutgoingAccessMode "UDP") (eq .Values.publicOutgoingAccessMode "any") }}
           - name: "[{{ $shortname }}] public-network-udp"
@@ -151,8 +160,8 @@ data:
             - "{{ $shortname }}:ext:net=public:udp"
             entries:
             - "0.0.0.0/0"
-            protocols:
-            - "udp"
+            servicePorts:
+            - "udp/1:65535"
           {{- end }}
           {{- if or (eq .Values.privateOutgoingAccessMode "TCP") (eq .Values.privateOutgoingAccessMode "any") (eq .Values.privateIncomingAccessMode "TCP") (eq .Values.privateIncomingAccessMode "any") }}
           - name: "[{{ $shortname }}] private-network-tcp"
@@ -163,8 +172,8 @@ data:
             - "10.0.0.0/8"
             - "172.16.0.0/12"
             - "192.168.0.0/16"
-            protocols:
-            - "tcp"
+            servicePorts:
+            - "tcp/1:65535"
           {{- end }}
           {{- if or (eq .Values.privateOutgoingAccessMode "UDP") (eq .Values.privateOutgoingAccessMode "any") (eq .Values.privateIncomingAccessMode "UDP") (eq .Values.privateIncomingAccessMode "any") }}
           - name: "[{{ $shortname }}] private-network-udp"
@@ -175,8 +184,8 @@ data:
             - "10.0.0.0/8"
             - "172.16.0.0/12"
             - "192.168.0.0/16"
-            protocols:
-            - "udp"
+            servicePorts:
+            - "udp/1:65535"
           {{- end }}
           `}}
 

--- a/quickstart-k8s.yaml
+++ b/quickstart-k8s.yaml
@@ -127,8 +127,7 @@ data:
                         description: 'Created by an automation on namespace creation. It is safe to be deleted, if not required.',
                         metadata: ['@ext:name=tcpall'],
                         entries: ['0.0.0.0/0'],
-                        ports: ['1:65535'],
-                        protocols: ['tcp'],
+                        servicePorts: ['tcp/1:65535'],
                         propagate: true,
                     }, payload.namespace.name);
                     api.Create('externalnetwork', {
@@ -136,8 +135,7 @@ data:
                         description: 'Created by an automation on namespace creation. It is safe to be deleted, if not required.',
                         metadata: ['@ext:name=udpall'],
                         entries: ['0.0.0.0/0'],
-                        ports: ['1:65535'],
-                        protocols: ['udp'],
+                        servicePorts: ['udp/1:65535'],
                         propagate: true,
                     }, payload.namespace.name);
                     api.Create('networkaccesspolicy', {

--- a/quickstart-linux.yaml
+++ b/quickstart-linux.yaml
@@ -158,10 +158,8 @@ data:
             description: "This external network has been created from the linux workflow"
             entries:
             - "0.0.0.0/0"
-            ports:
-            - "53"
-            protocols:
-            - "udp"
+            servicePorts:
+            - "udp/53"
             associatedTags:
             - "extnet:name=dns"
           {{- end}}
@@ -173,10 +171,8 @@ data:
             description: "This external network has been created from the linux workflow"
             entries:
             - "0.0.0.0/0"
-            ports:
-            - "1:65535"
-            protocols:
-            - "tcp"
+            servicePorts:
+            - "tcp/1:65535"
             associatedTags:
             - "extnet:name=internet"
           {{- end}}

--- a/quickstart-ssh-protection.yaml
+++ b/quickstart-ssh-protection.yaml
@@ -130,12 +130,10 @@ data:
           - "ext:net=internet"
           entries:
           - "0.0.0.0/0"
-          protocols:
-          - udp
-          - tcp
-          - icmp
-          ports:
-          - "1:65535"
+          servicePorts:
+          - "udp/1:65535"
+          - "tcp/1:65535"
+          - "icmp"
 
         networkaccesspolicies:
         - name: "Allow all UDP/TCP/ICMP traffic from/to an SSH Session"

--- a/sync-subnets-aws.yaml
+++ b/sync-subnets-aws.yaml
@@ -25,13 +25,11 @@ data:
         - name: aws-{{ .Values.region | lower }}-{{ .Values.serviceType | lower }}-networks
           entries:
           - "0.0.0.1/32"
-          ports:
-          {{- range $idx, $port := .Values.ports }}
-          - "{{ $port }}"
-          {{- end }}
-          protocols:
+          servicePorts:
           {{- range $idx, $protocol := .Values.protocols }}
-          - "{{ $protocol }}"
+          {{- range $idx, $port := .Values.ports }}
+          - "{{ $protocol }}/{{ $port }}"
+          {{- end }}
           {{- end }}
           associatedTags:
           - 'recipe:renderid={{ .RenderID }}'

--- a/sync-subnets-cloudflare.yaml
+++ b/sync-subnets-cloudflare.yaml
@@ -25,13 +25,11 @@ data:
         - name: cloudflare-networks
           entries:
           - "0.0.0.1/32"
-          ports:
-          {{- range $idx, $port := .Values.ports }}
-          - "{{ $port }}"
-          {{- end }}
-          protocols:
+          servicePorts:
           {{- range $idx, $protocol := .Values.protocols }}
-          - "{{ $protocol }}"
+          {{- range $idx, $port := .Values.ports }}
+          - "{{ $protocol }}/{{ $port }}"
+          {{- end }}
           {{- end }}
           associatedTags :
           - 'recipe:renderid={{ .RenderID }}'


### PR DESCRIPTION
* Update: Move some of the recipes to v2 external network model

* Update: Move the rest of the recipes over

* Fixed: ICMP cannot have port ranges