### PR TITLE
Update: Remove protection (to align with UI change)

### DIFF
--- a/policy-suggest-amazon-linux-update.yaml
+++ b/policy-suggest-amazon-linux-update.yaml
@@ -10,6 +10,8 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=system-update"
+        - "aporeto:recipe:placement=group-level"
+        - "aporeto:recipe:placement=kubernetes-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-amazon-linux-update.yaml
+++ b/policy-suggest-amazon-linux-update.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: amazon_linux_update
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: amazon_linux_update
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-authorized-registries.yaml
+++ b/policy-suggest-authorized-registries.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: authorized_registries
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: authorized_registries
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-dchp.yaml
+++ b/policy-suggest-dchp.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: dhcp
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: dhcp
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-dchp.yaml
+++ b/policy-suggest-dchp.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=infrastructure"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-dns.yaml
+++ b/policy-suggest-dns.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: dns
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: dns
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-dns.yaml
+++ b/policy-suggest-dns.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=infrastructure"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-inter-namespace.yaml
+++ b/policy-suggest-inter-namespace.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=inter-namespace"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: Unrestricted
       targetIdentities:
         - networkrulesetpolicy

--- a/policy-suggest-inter-namespace.yaml
+++ b/policy-suggest-inter-namespace.yaml
@@ -27,7 +27,6 @@ data:
           networkrulesetpolicies:
           - name: inter-namespace-first
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             namespace: {{ .Values.namespace1Path }}
             incomingRules:
@@ -58,7 +57,6 @@ data:
             {{- end }}
           - name: inter-namespace-second
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             namespace: {{ .Values.namespace2Path }}
             incomingRules:

--- a/policy-suggest-intra-group-namespaces.yaml
+++ b/policy-suggest-intra-group-namespaces.yaml
@@ -28,7 +28,6 @@ data:
           networkrulesetpolicies:
           - name: auto-secure_intra-vm_groups
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-intra-k8s-namespaces.yaml
+++ b/policy-suggest-intra-k8s-namespaces.yaml
@@ -28,7 +28,6 @@ data:
           networkrulesetpolicies:
           - name: auto-secure_intra-k8s_namespaces
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-k8s-api-server.yaml
+++ b/policy-suggest-k8s-api-server.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: "kube-api server"
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: "Allow incoming and outgoing to kube-api server"
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-kubelet.yaml
+++ b/policy-suggest-kubelet.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: k8s_nodes
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: "Allow Kubelet"
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-metadata-service.yaml
+++ b/policy-suggest-metadata-service.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: metadata_service
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: metadata_service
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-metadata-service.yaml
+++ b/policy-suggest-metadata-service.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=infrastructure"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-node-to-node.yaml
+++ b/policy-suggest-node-to-node.yaml
@@ -28,7 +28,6 @@ data:
           networkrulesetpolicies:
           - name: "Allow Node to Node"
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-nodeport-addresses.yaml
+++ b/policy-suggest-nodeport-addresses.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: nodeport_addresses
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: nodeport_addresses
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-ntp.yaml
+++ b/policy-suggest-ntp.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: ntp
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: ntp
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-ntp.yaml
+++ b/policy-suggest-ntp.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=infrastructure"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-oracle-linux-update.yaml
+++ b/policy-suggest-oracle-linux-update.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: oracle_linux_update
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: oracle_linux_update
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-oracle-linux-update.yaml
+++ b/policy-suggest-oracle-linux-update.yaml
@@ -10,6 +10,8 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=system-update"
+        - "aporeto:recipe:placement=group-level"
+        - "aporeto:recipe:placement=kubernetes-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-probes-from-nodes.yaml
+++ b/policy-suggest-probes-from-nodes.yaml
@@ -28,7 +28,6 @@ data:
           networkrulesetpolicies:
           - name: "Allow Liveness/Readiness Probes from Nodes"
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-probes-to-pods.yaml
+++ b/policy-suggest-probes-to-pods.yaml
@@ -28,7 +28,6 @@ data:
           networkrulesetpolicies:
           - name: "Allow Liveness/Readiness Probes to Pods"
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-rdp.yaml
+++ b/policy-suggest-rdp.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: mgmt_rdp_network
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: mgmt_rdp_network
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-rdp.yaml
+++ b/policy-suggest-rdp.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=infrastructure"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-redhat-update.yaml
+++ b/policy-suggest-redhat-update.yaml
@@ -10,6 +10,8 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=system-update"
+        - "aporeto:recipe:placement=group-level"
+        - "aporeto:recipe:placement=kubernetes-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-redhat-update.yaml
+++ b/policy-suggest-redhat-update.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: redhat_update
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: redhat_update
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-ssh-to-nodes.yaml
+++ b/policy-suggest-ssh-to-nodes.yaml
@@ -29,7 +29,6 @@ data:
           externalnetworks:
           - name: management_addresses
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -40,7 +39,6 @@ data:
           networkrulesetpolicies:
           - name: management_addresses
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-ssh.yaml
+++ b/policy-suggest-ssh.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: mgmt_ssh_network
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: mgmt_ssh_network
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             incomingRules:
             - action: Allow

--- a/policy-suggest-ssh.yaml
+++ b/policy-suggest-ssh.yaml
@@ -10,6 +10,9 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=infrastructure"
+        - "aporeto:recipe:placement=tenant-level"
+        - "aporeto:recipe:placement=cloudaccount-level"
+        - "aporeto:recipe:placement=group-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-suse-update.yaml
+++ b/policy-suggest-suse-update.yaml
@@ -10,6 +10,8 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=system-update"
+        - "aporeto:recipe:placement=group-level"
+        - "aporeto:recipe:placement=kubernetes-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-suse-update.yaml
+++ b/policy-suggest-suse-update.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: suse_update
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: suse_update
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-ubuntu-update.yaml
+++ b/policy-suggest-ubuntu-update.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: ubuntu_update
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: ubuntu_update
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow

--- a/policy-suggest-ubuntu-update.yaml
+++ b/policy-suggest-ubuntu-update.yaml
@@ -10,6 +10,8 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=system-update"
+        - "aporeto:recipe:placement=group-level"
+        - "aporeto:recipe:placement=kubernetes-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-windows-update.yaml
+++ b/policy-suggest-windows-update.yaml
@@ -10,6 +10,8 @@ data:
       associatedTags:
         - "aporeto:recipe:placement=policy-suggest"
         - "aporeto:recipe:placement=system-update"
+        - "aporeto:recipe:placement=group-level"
+        - "aporeto:recipe:placement=kubernetes-level"
       deploymentMode: NamespaceUnique
       targetIdentities:
         - externalnetwork

--- a/policy-suggest-windows-update.yaml
+++ b/policy-suggest-windows-update.yaml
@@ -28,7 +28,6 @@ data:
           externalnetworks:
           - name: windows_update
             description: "External network automatically created by an Out of Box template."
-            protected: true
             propagate: true
             entries:
             {{- range $_, $network := .Values.networks }}
@@ -39,7 +38,6 @@ data:
           networkrulesetpolicies:
           - name: windows_update
             description: "Ruleset automatically created by an Out of Box template."
-            protected: true
             propagate: true
             outgoingRules:
             - action: Allow


### PR DESCRIPTION
#### Description
After discussion, we decided to flip the script around and remove protection from recipe objects, but hide the delete button in the UI. This way we expose edit and clone buttons on deployed objects which is one of the asks in https://redlock.atlassian.net/browse/CNS-3079

> Policies created using OOB rules should not be removed if the action is executed directly in rulesets tab. 
OOB rulesets can be cloned or modified from there, but not removed.
Deletion should only occur if the action is triggered using the “remove” button in the “Out of Box rules” tab