### PR TITLE
Update: Add repo.aporeto.us and align policies

### DIFF
--- a/policy-suggest-amazon-linux-update.yaml
+++ b/policy-suggest-amazon-linux-update.yaml
@@ -36,7 +36,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=amazon_linux_update'
+            - "externalnetwork:name=amazon_linux_update"
           networkrulesetpolicies:
           - name: amazon_linux_update
             description: "Ruleset automatically created by an Out of Box template."
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=amazon_linux_update'
+              - - "externalnetwork:name=amazon_linux_update"
               protocolPorts:
               - tcp/80
               - tcp/443
@@ -69,6 +69,7 @@ data:
                 Provide at least one CIDR or FQDN. Example 52.17.12.0/16,google.com
               type: StringSlice
               defaultValue:
+              - "repo.aporeto.us"
               - "*.us-east-1.amazonaws.com"
               - "*.us-east-2.amazonaws.com"
               - "*.us-west-1.amazonaws.com"

--- a/policy-suggest-authorized-registries.yaml
+++ b/policy-suggest-authorized-registries.yaml
@@ -35,7 +35,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=authorized_registries'
+            - "externalnetwork:name=authorized_registries"
           networkrulesetpolicies:
           - name: authorized_registries
             description: "Ruleset automatically created by an Out of Box template."
@@ -43,12 +43,12 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=authorized_registries'
+              - - "externalnetwork:name=authorized_registries"
               protocolPorts:
               - any
             subject:
-            - - $identity=processingunit
-              - app:host:type=kubernetes
+            - - "$identity=processingunit"
+              - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}

--- a/policy-suggest-dchp.yaml
+++ b/policy-suggest-dchp.yaml
@@ -38,7 +38,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=dhcp'
+            - "externalnetwork:name=dhcp"
           networkrulesetpolicies:
           - name: dhcp
             description: "Ruleset automatically created by an Out of Box template."
@@ -46,13 +46,13 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=dhcp'
+              - - "externalnetwork:name=dhcp"
               protocolPorts:
               - udp/68
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=dhcp'
+              - - "externalnetwork:name=dhcp"
               protocolPorts:
               - udp/67
             subject:

--- a/policy-suggest-dns.yaml
+++ b/policy-suggest-dns.yaml
@@ -37,7 +37,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=dns'
+            - "externalnetwork:name=dns"
           networkrulesetpolicies:
           - name: dns
             description: "Ruleset automatically created by an Out of Box template."
@@ -45,7 +45,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=dns'
+              - - "externalnetwork:name=dns"
               protocolPorts:
               - udp/53
             subject:

--- a/policy-suggest-inter-namespace.yaml
+++ b/policy-suggest-inter-namespace.yaml
@@ -35,7 +35,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - '$identity=processingunit'
+              - - "$identity=processingunit"
               {{- range $_, $tag := .Values.namespace2Tags }}
                 - {{ $tag | quote }}
               {{- end }}
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - '$identity=processingunit'
+              - - "$identity=processingunit"
               {{- range $_, $tag := .Values.namespace2Tags }}
                 - {{ $tag | quote }}
               {{- end }}
@@ -65,7 +65,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - '$identity=processingunit'
+              - - "$identity=processingunit"
               {{- range $_, $tag := .Values.namespace1Tags }}
                 - {{ $tag | quote }}
               {{- end }}
@@ -74,7 +74,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - '$identity=processingunit'
+              - - "$identity=processingunit"
               {{- range $_, $tag := .Values.namespace1Tags }}
                 - {{ $tag | quote }}
               {{- end }}

--- a/policy-suggest-intra-group-namespaces.yaml
+++ b/policy-suggest-intra-group-namespaces.yaml
@@ -32,7 +32,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - $identity=processingunit
+              - - "$identity=processingunit"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}
@@ -41,7 +41,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - $identity=processingunit
+              - - "$identity=processingunit"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}

--- a/policy-suggest-intra-k8s-namespaces.yaml
+++ b/policy-suggest-intra-k8s-namespaces.yaml
@@ -32,7 +32,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - $identity=processingunit
+              - - "$identity=processingunit"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}
@@ -41,7 +41,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - $identity=processingunit
+              - - "$identity=processingunit"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}

--- a/policy-suggest-k8s-api-server.yaml
+++ b/policy-suggest-k8s-api-server.yaml
@@ -35,7 +35,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=k8s-api-server'
+            - "externalnetwork:name=k8s-api-server"
           networkrulesetpolicies:
           - name: "Allow incoming and outgoing to kube-api server"
             description: "Ruleset automatically created by an Out of Box template."
@@ -43,17 +43,17 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=k8s-api-server'
+              - - "externalnetwork:name=k8s-api-server"
               protocolPorts:
               - any
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=k8s-api-server'
+              - - "externalnetwork:name=k8s-api-server"
               protocolPorts:
               - any
             subject:
-            - - $identity=processingunit
+            - - "$identity=processingunit"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}

--- a/policy-suggest-kubelet.yaml
+++ b/policy-suggest-kubelet.yaml
@@ -35,7 +35,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=k8s_nodes'
+            - "externalnetwork:name=k8s_nodes"
           networkrulesetpolicies:
           - name: "Allow Kubelet"
             description: "Ruleset automatically created by an Out of Box template."
@@ -43,7 +43,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=k8s_nodes'
+              - - "externalnetwork:name=k8s_nodes"
               protocolPorts:
               - any
             subject:

--- a/policy-suggest-metadata-service.yaml
+++ b/policy-suggest-metadata-service.yaml
@@ -38,7 +38,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=metadata_service'
+            - "externalnetwork:name=metadata_service"
           networkrulesetpolicies:
           - name: metadata_service
             description: "Ruleset automatically created by an Out of Box template."
@@ -46,7 +46,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=metadata_service'
+              - - "externalnetwork:name=metadata_service"
               protocolPorts:
               - tcp/80
               - tcp/443

--- a/policy-suggest-node-to-node.yaml
+++ b/policy-suggest-node-to-node.yaml
@@ -32,8 +32,8 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - $identity=processingunit
-                - app:host:type=kubernetes
+              - - "$identity=processingunit"
+                - "app:host:type=kubernetes"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}
@@ -42,16 +42,16 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - $identity=processingunit
-                - app:host:type=kubernetes
+              - - "$identity=processingunit"
+                - "app:host:type=kubernetes"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}
               protocolPorts:
               - any
             subject:
-            - - $identity=processingunit
-              - app:host:type=kubernetes
+            - - "$identity=processingunit"
+              - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}

--- a/policy-suggest-nodeport-addresses.yaml
+++ b/policy-suggest-nodeport-addresses.yaml
@@ -35,7 +35,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=nodeport_addresses'
+            - "externalnetwork:name=nodeport_addresses"
           networkrulesetpolicies:
           - name: nodeport_addresses
             description: "Ruleset automatically created by an Out of Box template."
@@ -43,12 +43,12 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=nodeport_addresses'
+              - - "externalnetwork:name=nodeport_addresses"
               protocolPorts:
               - tcp/30000:32767
             subject:
-            - - $identity=processingunit
-              - app:host:type=kubernetes
+            - - "$identity=processingunit"
+              - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}

--- a/policy-suggest-ntp.yaml
+++ b/policy-suggest-ntp.yaml
@@ -37,7 +37,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=ntp'
+            - "externalnetwork:name=ntp"
           networkrulesetpolicies:
           - name: ntp
             description: "Ruleset automatically created by an Out of Box template."
@@ -45,7 +45,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=ntp'
+              - - "externalnetwork:name=ntp"
               protocolPorts:
               - udp/123
             subject:

--- a/policy-suggest-oracle-linux-update.yaml
+++ b/policy-suggest-oracle-linux-update.yaml
@@ -36,7 +36,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=oracle_linux_update'
+            - "externalnetwork:name=oracle_linux_update"
           networkrulesetpolicies:
           - name: oracle_linux_update
             description: "Ruleset automatically created by an Out of Box template."
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=oracle_linux_update'
+              - - "externalnetwork:name=oracle_linux_update"
               protocolPorts:
               - tcp/80
               - tcp/443
@@ -69,6 +69,7 @@ data:
                 Provide at least one CIDR or FQDN. Example 52.17.12.0/16,google.com
               type: StringSlice
               defaultValue:
+              - "repo.aporeto.us"
               - "public-yum.oracle.com"
               - "yum-ap-sidney-1.oracle.com"
               - "yum-ap-melbourne-1.oracle.com"

--- a/policy-suggest-probes-from-nodes.yaml
+++ b/policy-suggest-probes-from-nodes.yaml
@@ -39,8 +39,8 @@ data:
               protocolPorts:
               - any
             subject:
-            - - $identity=processingunit
-              - app:host:type=kubernetes
+            - - "$identity=processingunit"
+              - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}

--- a/policy-suggest-probes-to-pods.yaml
+++ b/policy-suggest-probes-to-pods.yaml
@@ -32,14 +32,14 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - app:host:type=kubernetes
+              - - "app:host:type=kubernetes"
               {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
                 - {{ $orgmeta | quote }}
               {{- end }}
               protocolPorts:
               - any
             subject:
-            - - $identity=processingunit
+            - - "$identity=processingunit"
               - $type=Docker
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}

--- a/policy-suggest-rdp.yaml
+++ b/policy-suggest-rdp.yaml
@@ -37,7 +37,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=mgmt_rdp_network'
+            - "externalnetwork:name=mgmt_rdp_network"
           networkrulesetpolicies:
           - name: mgmt_rdp_network
             description: "Ruleset automatically created by an Out of Box template."
@@ -45,7 +45,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=mgmt_rdp_network'
+              - - "externalnetwork:name=mgmt_rdp_network"
               protocolPorts:
               - tcp/3389
             subject:

--- a/policy-suggest-redhat-update.yaml
+++ b/policy-suggest-redhat-update.yaml
@@ -36,7 +36,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=redhat_update'
+            - "externalnetwork:name=redhat_update"
           networkrulesetpolicies:
           - name: redhat_update
             description: "Ruleset automatically created by an Out of Box template."
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=redhat_update'
+              - - "externalnetwork:name=redhat_update"
               protocolPorts:
               - tcp/80
               - tcp/443
@@ -69,6 +69,7 @@ data:
                 Provide at least one CIDR or FQDN. Example 52.17.12.0/16,google.com
               type: StringSlice
               defaultValue:
+              - "repo.aporeto.us"
               - "download.fedoraproject.org"
               - "mirrors.fedoraproject.org"
               - "packages.cloud.google.com"

--- a/policy-suggest-ssh-to-nodes.yaml
+++ b/policy-suggest-ssh-to-nodes.yaml
@@ -35,7 +35,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=management_addresses'
+            - "externalnetwork:name=management_addresses"
           networkrulesetpolicies:
           - name: management_addresses
             description: "Ruleset automatically created by an Out of Box template."
@@ -43,12 +43,12 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=management_addresses'
+              - - "externalnetwork:name=management_addresses"
               protocolPorts:
               - tcp/22
             subject:
-            - - $identity=processingunit
-              - $type=Host
+            - - "$identity=processingunit"
+              - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}

--- a/policy-suggest-ssh.yaml
+++ b/policy-suggest-ssh.yaml
@@ -37,7 +37,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=mgmt_ssh_network'
+            - "externalnetwork:name=mgmt_ssh_network"
           networkrulesetpolicies:
           - name: mgmt_ssh_network
             description: "Ruleset automatically created by an Out of Box template."
@@ -45,7 +45,7 @@ data:
             incomingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=mgmt_ssh_network'
+              - - "externalnetwork:name=mgmt_ssh_network"
               protocolPorts:
               - tcp/22
             subject:

--- a/policy-suggest-suse-update.yaml
+++ b/policy-suggest-suse-update.yaml
@@ -36,7 +36,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=suse_update'
+            - "externalnetwork:name=suse_update"
           networkrulesetpolicies:
           - name: suse_update
             description: "Ruleset automatically created by an Out of Box template."
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=suse_update'
+              - - "externalnetwork:name=suse_update"
               protocolPorts:
               - tcp/80
               - tcp/443
@@ -69,5 +69,6 @@ data:
                 Provide at least one CIDR or FQDN. Example 52.17.12.0/16,google.com
               type: StringSlice
               defaultValue:
+              - "repo.aporeto.us"
               - "download.opensuse.org"
               - "packagehub.suse.com"

--- a/policy-suggest-ubuntu-update.yaml
+++ b/policy-suggest-ubuntu-update.yaml
@@ -36,7 +36,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=ubuntu_update'
+            - "externalnetwork:name=ubuntu_update"
           networkrulesetpolicies:
           - name: ubuntu_update
             description: "Ruleset automatically created by an Out of Box template."
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=ubuntu_update'
+              - - "externalnetwork:name=ubuntu_update"
               protocolPorts:
               - tcp/80
               - tcp/443
@@ -69,6 +69,7 @@ data:
                 Provide at least one CIDR or FQDN. Example 52.17.12.0/16,google.com
               type: StringSlice
               defaultValue:
+              - "repo.aporeto.us"
               - "*.archive.ubuntu.com"
               - "*.archive.canonical.com"
               - "security.ubuntu.com"

--- a/policy-suggest-windows-update.yaml
+++ b/policy-suggest-windows-update.yaml
@@ -36,7 +36,7 @@ data:
             - {{ $network | quote }}
             {{- end }}
             associatedTags:
-            - 'externalnetwork:name=windows_update'
+            - "externalnetwork:name=windows_update"
           networkrulesetpolicies:
           - name: windows_update
             description: "Ruleset automatically created by an Out of Box template."
@@ -44,7 +44,7 @@ data:
             outgoingRules:
             - action: Allow
               object:
-              - - 'externalnetwork:name=windows_update'
+              - - "externalnetwork:name=windows_update"
               protocolPorts:
               - tcp/80
               - tcp/443
@@ -69,6 +69,7 @@ data:
                 Provide at least one CIDR or FQDN. Example 52.17.12.0/16,google.com
               type: StringSlice
               defaultValue:
+              - "repo.aporeto.us"
               - "*.windowsupdate.microsoft.com"
               - "*.update.microsoft.com"
               - "*.windowsupdate.com"


### PR DESCRIPTION
#### Description
As we get through testing, it was noticed that a few tweaks were needed:
- Add `repo.aporeto.us` to all system update rules
- Swap one policy over to `app:host:type=kubernetes` from `$type=Host`
- Use double-quotes for all tags to be consistent

> Fixes: https://redlock.atlassian.net/browse/CNS-3349 and https://redlock.atlassian.net/browse/CNS-3444