### PR TITLE
New: Add konnectivity service rule for k8s host mode

### DIFF
--- a/policy-suggest-konnectivity.yaml
+++ b/policy-suggest-konnectivity.yaml
@@ -26,13 +26,13 @@ data:
         APIVersion: 1
         data:
           networkrulesetpolicies:
-          - name: "Allow Konnectivity apps to talk to the K8s nodes"
+          - name: "Allow Konnectivity apps to talk to the k8s nodes"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
             incomingRules:
             - action: Allow
               object:
-              - - "k8s-app=konnectivity-agent"
+              - - "$image=gke.gcr.io/proxy-agent:v0.0.24-gke.0"
               protocolPorts:
               - tcp/10250
             subject:

--- a/policy-suggest-konnectivity.yaml
+++ b/policy-suggest-konnectivity.yaml
@@ -1,0 +1,44 @@
+APIVersion: 1
+label: recipe:policy-suggest:konnectivity
+data:
+  recipes:
+    - name: K8s Host Mode - Create Konnectivity Service Rule
+      description: Creates a node to node rule to allow traffic between kubernetes nodes.
+      label: recipe:policy-suggest:konnectivity
+      metadata:
+        - "@aporeto:author=aporeto"
+      associatedTags:
+        - "aporeto:recipe:placement=policy-suggest"
+        - "aporeto:recipe:placement=k8s-rules"
+        - "aporeto:recipe:placement=group-level"
+      deploymentMode: NamespaceUnique
+      targetIdentities:
+        - networkrulesetpolicy
+      propagate: true
+      longDescription: |-
+        ### Create a Konnectivity service rule
+
+        This recipe will create a Network Ruleset Policy to allow incoming
+        traffic to the host from konnectivity apps on tcp/10250 port.
+
+      template: |-
+        {{`
+        APIVersion: 1
+        data:
+          networkrulesetpolicies:
+          - name: "Allow Konnectivity apps to talk to the K8s nodes"
+            description: "Ruleset automatically created by an Out of Box template."
+            propagate: true
+            incomingRules:
+            - action: Allow
+              object:
+              - - "k8s-app=konnectivity-agent"
+              protocolPorts:
+              - tcp/10250
+            subject:
+            - - "$type=Host"
+              - "app:host:type=kubernetes"
+            {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+              - {{ $orgmeta | quote }}
+            {{- end }}
+        `}}

--- a/policy-suggest-konnectivity.yaml
+++ b/policy-suggest-konnectivity.yaml
@@ -3,7 +3,7 @@ label: recipe:policy-suggest:konnectivity
 data:
   recipes:
     - name: K8s Host Mode - Create Konnectivity Service Rule
-      description: Creates a node to node rule to allow traffic between kubernetes nodes.
+      description: Creates a rule to allow incoming traffic from Konnectivity apps.
       label: recipe:policy-suggest:konnectivity
       metadata:
         - "@aporeto:author=aporeto"


### PR DESCRIPTION
#### Description
We want a new OOB rule that covers the k8s konnectivity service.

> Fixes: https://redlock.atlassian.net/browse/CNS-3663