### PR TITLE
New: Automation Integrations introducing send email, send slack, and ruleset alert

### DIFF
--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -1,0 +1,29 @@
+APIVersion: 1
+label: automation:condition:flows_reports_matching_rulesets
+identities:
+- automationcondition
+data:
+  automationconditions:
+  - key: '@condition:flows_reports_matching_rulesets'
+    name: When the number of flow reports exceeds a certain limit when matching to the specified rulesets
+    propagate: true
+    description: Continue if the number of flow reports exceeds a certain limit for the specified ruleset policies.
+    entitlements:
+      reportsquery:
+      - create
+    function: |-
+      function when(m, params) {
+
+      }
+    steps:
+    - name: Parameters
+      parameters:
+      - name: Ruleset Policy IDs
+        key: ruleset_ids
+        description: The identifiers of the ruleset policies to match to.
+        type: StringSlice
+      - name: Limit
+        key: limit
+        description: The triggering limit in which the condition is met.
+        type: Integer
+        defaultValue: 1

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -13,7 +13,29 @@ data:
       - create
     function: |-
       function when(m, params) {
-
+        if (!params.ruleset_ids) {
+          throw 'Parameter "ruleset_ids" must be set';
+        }
+        if (!params.limit) {
+          throw 'Parameter "limit" must be set';
+        }
+        const payload = m.Create(
+          'reportsqueries',
+          {
+            report: 'Flows',
+          },
+          null,
+          {
+            q: params.ruleset_ids.map(id => `policyID == "${id}"`).join(' OR '),
+            startRelative: 5m,
+            recursive: true,
+          },
+        );
+        const flowReportsCount = _.countBy(payload.flowReports, 'policyID');
+        const continue = _.some(flowReportsCount, count => count >= params.hits_limit);
+        return {
+          continue,
+        }
       }
     steps:
     - name: Parameters

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -19,7 +19,14 @@ data:
         if (!params.limit) {
           throw 'Parameter "limit" must be set';
         }
-        const payload = m.Create(
+        if (!params.title) {
+          return { continue: false };
+        }
+        if (!params.content) {
+          return { continue: false };
+        }
+
+        const reportQuery = m.Create(
           'reportsqueries',
           {
             report: 'Flows',
@@ -31,10 +38,16 @@ data:
             recursive: true,
           },
         );
-        const flowReportsCount = _.countBy(payload.flowReports, 'policyID');
+
+        const flowReportsCount = _.countBy(reportQuery.flowReports, 'policyID');
         const continue = _.some(flowReportsCount, count => count >= params.hits_limit);
+
         return {
           continue,
+          payload: {
+            title: params.title,
+            content: params.content + "\n\nAffected Ruleset: " + policyID + "\nNamespace: " + policyNamespace + "\n\nFlow Details\n" + flowDetails
+          }
         }
       }
     steps:
@@ -48,4 +61,11 @@ data:
         key: limit
         description: The triggering limit in which the condition is met.
         type: Integer
-        defaultValue: 1
+      - name: Title
+        key: title
+        optional: true
+        type: String
+      - name: Content
+        key: content
+        optional: true
+        type: String

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -70,7 +70,7 @@ data:
           return flowCount >= params.hits_limit;
         });
 
-        var flowDetails = [timeOfEvent, sourceIP, sourceName, sourceNamespace,destinationIP, destinationName, destinationNamespace, protocol, destinationPort, hits].join(', ')
+        var flowDetails = [timeOfEvent, sourceIP, sourceName, sourceNamespace, destinationIP, destinationName, destinationNamespace, protocol, destinationPort, hits].join(', ')
 
         return {
           continue: condition,

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -26,27 +26,35 @@ data:
           return { continue: false };
         }
 
-        const reportQuery = m.Create(
+        var reportQuery = m.Create(
           'reportsqueries',
           {
             report: 'Flows',
           },
           null,
           {
-            q: params.ruleset_ids.map(id => `policyID == "${id}"`).join(' OR '),
-            startRelative: 5m,
-            recursive: true,
-          },
+            q: params.ruleset_ids.map(function(id) { return 'policyID == "' + id + '"'; }).join(' OR '),
+            startRelative: '5m',
+            recursive: 'true',
+          }
         );
 
-        const flowReportsCount = _.countBy(reportQuery.flowReports, 'policyID');
-        const continue = _.some(flowReportsCount, count => count >= params.hits_limit);
+        var policyID;
+        var policyNamespace;
+        var flowCount;
+        var groupedFlowReports = _.groupBy(reportQuery.flowReports, 'policyID');
+        var condition = _.some(groupedFlowReports, function(flows, policy) {
+          policyID = policy;
+          policyNamespace = groupedFlowReports[policy][0].policyNamespace;
+          flowCount = flows.length;
+          return flowCount >= params.hits_limit;
+        });
 
         return {
-          continue,
+          continue: condition,
           payload: {
             title: params.title,
-            content: params.content + "\n\nAffected Ruleset: " + policyID + "\nNamespace: " + policyNamespace + "\n\nFlow Details\n" + flowDetails
+            content: params.content + "\n\nAffected Ruleset: " + policyID + "\nNamespace: " + policyNamespace + "\n\nFlow Details\n" + "total flow count " + flowCount + " exceeded the triggering limit of " + params.limit
           }
         }
       }

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -39,13 +39,33 @@ data:
           }
         );
 
-        var policyID;
-        var policyNamespace;
+        // Below are used for Flow Details
+        var policyID; // Affected ruleset
+        var timeOfEvent; // timestamp
+        var sourceIP;
+        var sourceName; // sourceID
+        var sourceNamespace; // policyNamespace
+        var destinationIP;
+        var destinationName; // destinationID
+        var destinationNamespace; // namespace
+        var destinationPort;
+        var protocol;
         var flowCount;
+        var hits;
+
         var groupedFlowReports = _.groupBy(reportQuery.flowReports, 'policyID');
         var condition = _.some(groupedFlowReports, function(flows, policy) {
           policyID = policy;
-          policyNamespace = groupedFlowReports[policy][0].policyNamespace;
+          timeOfEvent = groupedFlowReports[policy][0].timestamp;
+          sourceIP = groupedFlowReports[policy][0].sourceIP;
+          sourceName = groupedFlowReports[policy][0].sourceID;
+          sourceNamespace = groupedFlowReports[policy][0].policyNamespace;
+          destinationIP = groupedFlowReports[policy][0].destinationIP;
+          destinationName = groupedFlowReports[policy][0].destinationID;
+          destinationNamespace = groupedFlowReports[policy][0].namespace;
+          destinationPort = groupedFlowReports[policy][0].destinationPort;
+          protocol = groupedFlowReports[policy][0].protocol;
+          hits = groupedFlowReports[policy][0].value;
           flowCount = flows.length;
           return flowCount >= params.hits_limit;
         });
@@ -54,7 +74,19 @@ data:
           continue: condition,
           payload: {
             title: params.title,
-            content: params.content + "\n\nAffected Ruleset: " + policyID + "\nNamespace: " + policyNamespace + "\n\nFlow Details\n" + "total flow count " + flowCount + " exceeded the triggering limit of " + params.limit
+            content: params.content +
+              "\nTime of Event: " + timeOfEvent +
+              "\n\nAffected Ruleset: " + policyID +
+              "\nNamespace: " + sourceNamespace +
+              "\nSourceIP: " + sourceIP +
+              "\nSourceName: " + sourceName +
+              "\nDestinationIP: " + destinationIP +
+              "\nDestinationName: " + destinationName +
+              "\nDestinationNamespace: " + destinationNamespace +
+              "\nDestinationPort: " + destinationPort +
+              "\nProtocol: " + protocol +
+              "\nTotal flow count: " + flowCount +
+              "\nHits: " + hits
           }
         }
       }

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -70,23 +70,17 @@ data:
           return flowCount >= params.hits_limit;
         });
 
+        var flowDetails = [timeOfEvent, sourceIP, sourceName, sourceNamespace,destinationIP, destinationName, destinationNamespace, protocol, destinationPort, hits].join(', ')
+
         return {
           continue: condition,
           payload: {
             title: params.title,
             content: params.content +
-              "\nTime of Event: " + timeOfEvent +
               "\n\nAffected Ruleset: " + policyID +
               "\nNamespace: " + sourceNamespace +
-              "\nSourceIP: " + sourceIP +
-              "\nSourceName: " + sourceName +
-              "\nDestinationIP: " + destinationIP +
-              "\nDestinationName: " + destinationName +
-              "\nDestinationNamespace: " + destinationNamespace +
-              "\nDestinationPort: " + destinationPort +
-              "\nProtocol: " + protocol +
-              "\nTotal flow count: " + flowCount +
-              "\nHits: " + hits
+              "\n\nFlow details" +
+              "\n" + flowDetails
           }
         }
       }

--- a/automations/automation-condition-flow-reports-matching-rulesets.yaml
+++ b/automations/automation-condition-flow-reports-matching-rulesets.yaml
@@ -1,10 +1,10 @@
 APIVersion: 1
-label: automation:condition:flows_reports_matching_rulesets
+label: automation:condition:flow_reports_matching_rulesets
 identities:
 - automationcondition
 data:
   automationconditions:
-  - key: '@condition:flows_reports_matching_rulesets'
+  - key: '@condition:flow_reports_matching_rulesets'
     name: When the number of flow reports exceeds a certain limit when matching to the specified rulesets
     propagate: true
     description: Continue if the number of flow reports exceeds a certain limit for the specified ruleset policies.

--- a/automations/recipe-automation-action-send-email.yaml
+++ b/automations/recipe-automation-action-send-email.yaml
@@ -1,0 +1,57 @@
+APIVersion: 1
+label: recipe:automation-action:send-email
+data:
+  recipes:
+    - name: Create a Send Email Automation Action
+      description: Creates an automation action that creates an alerm and sends an email to the specified recipient(s).
+      label: recipe:automation-action:send-email
+      metadata:
+        - "@aporeto:author=aporeto"
+      associatedTags:
+        - "aporeto:recipe:placement=automation-action"
+      deploymentMode: NamespaceUnique
+      targetIdentities:
+        - automationaction
+      propagate: true
+      longDescription: |-
+        ### Create an automation action to create an alarm and send an email
+
+        This recipe will create an automation action that will create an alarm
+        and send an email to the specified recipient(s) with the details.
+
+      template: |-
+        {{`
+        APIVersion: 1
+        data:
+          automationactions:
+          - key: '@action:send_email'
+            name: Then create an alarm and send email(s)
+            propagate: true
+            description: The content of the alarm will be taken from the condition's payload 'message' key
+            entitlements:
+              alarm:
+              - create
+            function: |-
+              function then(m, params, payload) {
+                if (!payload.message) {
+                    throw 'Payload key "message" must be set';
+                }
+
+                m.Create('alarm', {
+                    name: payload.create_alarm_name,
+                    description: payload.create_alarm_description,
+                    emails: params.emails,
+                    kind: 'automation.create_alarm.'+params.automation_id,
+                    content: payload.message,
+                    data: payload.message_fields,
+                });
+            }
+          `}}
+
+      steps:
+        - name: Parameters
+          parameters:
+            - key: emails
+              name: Emails
+              description: The list of emails to be notified when the alarm is created
+              type: StringSlice

--- a/automations/recipe-automation-action-send-email.yaml
+++ b/automations/recipe-automation-action-send-email.yaml
@@ -9,7 +9,6 @@ data:
         - "@aporeto:author=aporeto"
       associatedTags:
         - "aporeto:recipe:placement=automation-action"
-      deploymentMode: NamespaceUnique
       targetIdentities:
         - automationaction
       propagate: true
@@ -24,7 +23,7 @@ data:
         APIVersion: 1
         data:
           automationactions:
-          - key: '@action:send_email'
+          - key: '@action:send_email_{{ .RenderID }}'
             name: Then create an alarm and send email(s)
             propagate: true
             description: The content of the alarm will be taken from the condition's payload 'message' key

--- a/automations/recipe-automation-action-send-email.yaml
+++ b/automations/recipe-automation-action-send-email.yaml
@@ -41,7 +41,11 @@ data:
 
                 m.Create('alarm', {
                     name: payload.title,
-                    emails: {{ .Values.emails }},
+                    emails: [
+                      {{- range $index, $email := .Values.emails }}
+                        {{- if $index}}, {{ end }}{{ $email | quote -}}
+                      {{ end -}}
+                    ],
                     kind: 'automation.create_alarm.'+params.automation_id,
                     content: payload.content,
                 });

--- a/automations/recipe-automation-action-send-email.yaml
+++ b/automations/recipe-automation-action-send-email.yaml
@@ -23,29 +23,30 @@ data:
         APIVersion: 1
         data:
           automationactions:
-          - key: '@action:send_email_{{ .RenderID }}'
+          - key: "@action:send_email_{{ .RenderID }}"
             name: Then create an alarm and send email(s)
             propagate: true
-            description: The content of the alarm will be taken from the condition's payload 'message' key
+            description: The content of the alarm will be taken from the condition's payload 'title' and 'content' keys
             entitlements:
               alarm:
               - create
             function: |-
               function then(m, params, payload) {
-                if (!payload.message) {
-                    throw 'Payload key "message" must be set';
+                if (!payload.title) {
+                    throw 'Payload key "title" must be set';
+                }
+                if (!payload.content) {
+                    throw 'Payload key "content" must be set';
                 }
 
                 m.Create('alarm', {
-                    name: payload.create_alarm_name,
-                    description: payload.create_alarm_description,
-                    emails: params.emails,
+                    name: payload.title,
+                    emails: {{ .Values.emails }},
                     kind: 'automation.create_alarm.'+params.automation_id,
-                    content: payload.message,
-                    data: payload.message_fields,
+                    content: payload.content,
                 });
-            }
-          `}}
+              }
+        `}}
 
       steps:
         - name: Parameters

--- a/automations/recipe-automation-action-send-email.yaml
+++ b/automations/recipe-automation-action-send-email.yaml
@@ -3,7 +3,7 @@ label: recipe:automation-action:send-email
 data:
   recipes:
     - name: Create a Send Email Automation Action
-      description: Creates an automation action that creates an alerm and sends an email to the specified recipient(s).
+      description: Creates an automation action that creates an alarm and sends an email to the specified recipient(s).
       label: recipe:automation-action:send-email
       metadata:
         - "@aporeto:author=aporeto"

--- a/automations/recipe-automation-action-send-slack.yaml
+++ b/automations/recipe-automation-action-send-slack.yaml
@@ -9,7 +9,6 @@ data:
         - "@aporeto:author=aporeto"
       associatedTags:
         - "aporeto:recipe:placement=automation-action"
-      deploymentMode: NamespaceUnique
       targetIdentities:
         - automationaction
       propagate: true
@@ -24,7 +23,7 @@ data:
         APIVersion: 1
         data:
           automationactions:
-          - key: '@action:send_slack'
+          - key: '@action:send_slack_{{ .RenderID }}'
             name: Then send a message to Slack
             propagate: true
             description: Sends a message into Slack using an existing Incoming WebHook.

--- a/automations/recipe-automation-action-send-slack.yaml
+++ b/automations/recipe-automation-action-send-slack.yaml
@@ -1,0 +1,72 @@
+APIVersion: 1
+label: recipe:automation-action:send-slack
+data:
+  recipes:
+    - name: Create a Send Slack Automation Action
+      description: Creates an automation action that posts to a specific Slack WebHook.
+      label: recipe:automation-action:send-slack
+      metadata:
+        - "@aporeto:author=aporeto"
+      associatedTags:
+        - "aporeto:recipe:placement=automation-action"
+      deploymentMode: NamespaceUnique
+      targetIdentities:
+        - automationaction
+      propagate: true
+      longDescription: |-
+        ### Create an automation action to post to a Slack WebHook
+
+        This recipe will create an automation action that will send
+        a provided message payload to a specified Slack WebHook.
+
+      template: |-
+        {{`
+        APIVersion: 1
+        data:
+          automationactions:
+          - key: '@action:send_slack'
+            name: Then send a message to Slack
+            propagate: true
+            description: Sends a message into Slack using an existing Incoming WebHook.
+            function: |-
+              function then(m, params, payload) {
+                if (!payload.message) {
+                    throw 'Payload key "message" must be set';
+                }
+
+                fields = [];
+                if (payload.message_fields) {
+                    for (i = 0; i < payload.message_fields.length; i++) {
+                        for (key in payload.message_fields[i]) {
+                            value = typeof(payload.message_fields[i][key]) != 'string' ? JSON.stringify(payload.message_fields[i][key]) : payload.message_fields[i][key];
+                            fields.push({
+                                title: key,
+                                value: value,
+                                short: true,
+                            })
+                        }
+                    }
+                }
+
+                body = JSON.stringify({
+                    text: payload.message,
+                    attachments: [{
+                        fields: fields,
+                    }]
+                });
+
+                aporeto.http(
+                    'POST',
+                    params.url,
+                    body
+                );
+            }
+          `}}
+
+      steps:
+        - name: Parameters
+          parameters:
+            - key: url
+              name: URL
+              description: Incoming WebHook Slack Endpoint
+              type: String

--- a/automations/recipe-automation-action-send-slack.yaml
+++ b/automations/recipe-automation-action-send-slack.yaml
@@ -23,44 +23,30 @@ data:
         APIVersion: 1
         data:
           automationactions:
-          - key: '@action:send_slack_{{ .RenderID }}'
+          - key: "@action:send_slack_{{ .RenderID }}"
             name: Then send a message to Slack
             propagate: true
-            description: Sends a message into Slack using an existing Incoming WebHook.
+            description: Sends a message to Slack using an existing Incoming WebHook.
             function: |-
               function then(m, params, payload) {
-                if (!payload.message) {
-                    throw 'Payload key "message" must be set';
+                if (!payload.title) {
+                    throw 'Payload key "title" must be set';
                 }
-
-                fields = [];
-                if (payload.message_fields) {
-                    for (i = 0; i < payload.message_fields.length; i++) {
-                        for (key in payload.message_fields[i]) {
-                            value = typeof(payload.message_fields[i][key]) != 'string' ? JSON.stringify(payload.message_fields[i][key]) : payload.message_fields[i][key];
-                            fields.push({
-                                title: key,
-                                value: value,
-                                short: true,
-                            })
-                        }
-                    }
+                if (!payload.content) {
+                    throw 'Payload key "content" must be set';
                 }
 
                 body = JSON.stringify({
-                    text: payload.message,
-                    attachments: [{
-                        fields: fields,
-                    }]
+                    text: payload.title + "\n\n" + payload.content,
                 });
 
                 aporeto.http(
                     'POST',
-                    params.url,
+                    {{ .Values.url }},
                     body
                 );
-            }
-          `}}
+              }
+        `}}
 
       steps:
         - name: Parameters

--- a/automations/recipe-automation-action-send-slack.yaml
+++ b/automations/recipe-automation-action-send-slack.yaml
@@ -42,7 +42,7 @@ data:
 
                 aporeto.http(
                     'POST',
-                    {{ .Values.url }},
+                    {{ .Values.url | quote }},
                     body
                 );
               }

--- a/automations/recipe-automation-ruleset-alert.yaml
+++ b/automations/recipe-automation-ruleset-alert.yaml
@@ -3,7 +3,7 @@ label: recipe:automation:ruleset-alert
 data:
   recipes:
     - name: Create a Ruleset Alert Automation
-      description: Creates an automation that will raise an alert when a ruleset reaches its limit in matcing flow report.
+      description: Creates an automation that will raise an alert when a ruleset reaches its limit in matching flow report.
       label: recipe:automation:ruleset-alert
       metadata:
         - "@aporeto:author=aporeto"

--- a/automations/recipe-automation-ruleset-alert.yaml
+++ b/automations/recipe-automation-ruleset-alert.yaml
@@ -13,7 +13,7 @@ data:
         - automation
       propagate: true
       longDescription: |-
-        ### Create an automation to alert when a ruleset reaches is flow report matching limit
+        ### Create an automation to alert when a ruleset reaches its flow report matching limit
 
         This recipe will create an automation that will raise an alarm when the specified
         ruleset policies reach their specified limit of matching flow reports.
@@ -25,19 +25,48 @@ data:
           automations:
           - name: Ruleset Alert
             trigger: Time
-            schedule: @every 5m
-            condition: @condition:flows_reports_matching_rulesets
+            schedule: "@every 5m"
+            condition: "@condition:flows_reports_matching_rulesets"
             actions:
             {{- range $_, $action := .Values.actions }}
             - {{ $action | quote }}
             {{- end }}
-          `}}
+            parameters:
+              ruleset_ids:
+              {{- range $_, $id := .Values.ruleset_ids }}
+              - {{ $id | quote }}
+              {{- end }}
+              limit: {{ .Values.limit }}
+              title: Ruleset Alert
+              content: |-
+                For full details, please see the logs on the Prisma Cloud Microsegmentation console
+                Alert Severity: {{ .Values.severity }}
+        `}}
 
       steps:
         - name: Parameters
           parameters:
-            - key: actions
-              name: Integrations
+            - name: Ruleset Policy IDs
+              key: ruleset_ids
+              description: The identifiers of the ruleset policies to track.
+              type: StringSlice
+            - name: Limit
+              key: limit
+              description: The triggering limit in which the condition is met.
+              type: Integer
+              defaultValue: 1
+            - name: Severity
+              key: severity
+              description: The severity of the message.
+              type: Enum
+              allowedChoices:
+                Low: Low
+                Medium: Medium
+                High: High
+                Critical: Critical
+              defaultValue: Low
+            - name: Integrations
+              key: actions
               description: The list of integrations to use when the alert is triggered.
               type: List
               subtype: AutomationAction

--- a/automations/recipe-automation-ruleset-alert.yaml
+++ b/automations/recipe-automation-ruleset-alert.yaml
@@ -26,7 +26,7 @@ data:
           - name: Ruleset Alert
             trigger: Time
             schedule: "@every 5m"
-            condition: "@condition:flows_reports_matching_rulesets"
+            condition: "@condition:flow_reports_matching_rulesets"
             actions:
             {{- range $_, $action := .Values.actions }}
             - {{ $action | quote }}

--- a/automations/recipe-automation-ruleset-alert.yaml
+++ b/automations/recipe-automation-ruleset-alert.yaml
@@ -1,0 +1,43 @@
+APIVersion: 1
+label: recipe:automation:ruleset-alert
+data:
+  recipes:
+    - name: Create a Ruleset Alert Automation
+      description: Creates an automation that will raise an alert when a ruleset reaches its limit in matcing flow report.
+      label: recipe:automation:ruleset-alert
+      metadata:
+        - "@aporeto:author=aporeto"
+      associatedTags:
+        - "aporeto:recipe:placement=automation"
+      targetIdentities:
+        - automation
+      propagate: true
+      longDescription: |-
+        ### Create an automation to alert when a ruleset reaches is flow report matching limit
+
+        This recipe will create an automation that will raise an alarm when the specified
+        ruleset policies reach their specified limit of matching flow reports.
+
+      template: |-
+        {{`
+        APIVersion: 1
+        data:
+          automations:
+          - name: Ruleset Alert
+            trigger: Time
+            schedule: @every 5m
+            condition: @condition:flows_reports_matching_rulesets
+            actions:
+            {{- range $_, $action := .Values.actions }}
+            - {{ $action | quote }}
+            {{- end }}
+          `}}
+
+      steps:
+        - name: Parameters
+          parameters:
+            - key: actions
+              name: Integrations
+              description: The list of integrations to use when the alert is triggered.
+              type: List
+              subtype: AutomationAction


### PR DESCRIPTION
#### Description
The next phase of automation support is Integrations (which are what we call actions). To make it a better UX, we want to covert relevant actions into recipes:
- Send Slack message
- Send Email(s)

We also want to use recipes for introducing our structure automations to customers. The first being Ruleset Alert which will do the following:
- Generate an alert for new flows matching a specific ruleset in a list of rulesets.
- This may indicate an attempt to violate a specify guardrail or a more sophisticated attack.
- The user must be able to specify what rulesets they wants to generate alerts upon (including the Namespace Default Ruleset).

TODO:
- [x] Integrate Severity, Title, and Content into Ruleset Alert (https://redlock.atlassian.net/wiki/spaces/RED/pages/3389128900/Automations+Alerts)
- [x] JS work to fill in condition for Ruleset Alert
- [x] Flow Details

> Fixes: https://redlock.atlassian.net/browse/CNS-3222