### PR TITLE
Fixed: Add recipe import step values to parameters

### DIFF
--- a/automations/recipe-automation-action-send-email.yaml
+++ b/automations/recipe-automation-action-send-email.yaml
@@ -48,6 +48,11 @@ data:
                     content: message,
                 });
               }
+            parameters:
+              emails:
+              {{- range $_, $email := .Values.emails }}
+              - {{ $email }}
+              {{- end }}
             steps:
             - name: Parameters
               parameters:

--- a/automations/recipe-automation-action-send-slack.yaml
+++ b/automations/recipe-automation-action-send-slack.yaml
@@ -48,6 +48,8 @@ data:
                     body
                 );
               }
+            parameters:
+              url: {{ .Values.url }}
             steps:
             - name: Parameters
               parameters:


### PR DESCRIPTION
#### Description
The recipes for automation actions need to also put the step values into parameters. This will allow the initial import to wrk as expected.