### PR TITLE
changed order of elements for policies in recipe yaml

### DIFF
--- a/policy-suggest-amazon-linux-update.yaml
+++ b/policy-suggest-amazon-linux-update.yaml
@@ -41,13 +41,6 @@ data:
           - name: amazon_linux_update
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=amazon_linux_update"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +49,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=amazon_linux_update"
           `}}
 
       steps:

--- a/policy-suggest-authorized-registries.yaml
+++ b/policy-suggest-authorized-registries.yaml
@@ -40,18 +40,18 @@ data:
           - name: authorized_registries
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=authorized_registries"
-              protocolPorts:
-              - any
             subject:
             - - "$identity=processingunit"
               - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "externalnetwork:name=authorized_registries"
           `}}
 
       steps:

--- a/policy-suggest-client-to-eks-node.yaml
+++ b/policy-suggest-client-to-eks-node.yaml
@@ -40,17 +40,17 @@ data:
           - name: "Allow clients to execute into EKS cluster pods"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=clients_eks"
-              protocolPorts:
-              - tcp/10250
             subject:
             - - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/10250
+              object:
+              - - "externalnetwork:name=clients_eks"
           `}}
 
       steps:

--- a/policy-suggest-dchp.yaml
+++ b/policy-suggest-dchp.yaml
@@ -43,18 +43,6 @@ data:
           - name: dhcp
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=dhcp"
-              protocolPorts:
-              - udp/68
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=dhcp"
-              protocolPorts:
-              - udp/67
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -63,6 +51,18 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - udp/68
+              object:
+              - - "externalnetwork:name=dhcp"
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - udp/67
+              object:
+              - - "externalnetwork:name=dhcp"
           `}}
 
       steps:

--- a/policy-suggest-dns.yaml
+++ b/policy-suggest-dns.yaml
@@ -42,12 +42,6 @@ data:
           - name: dns
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=dns"
-              protocolPorts:
-              - udp/53
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +50,12 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - udp/53
+              object:
+              - - "externalnetwork:name=dns"
         `}}
 
       steps:

--- a/policy-suggest-inter-namespace.yaml
+++ b/policy-suggest-inter-namespace.yaml
@@ -32,24 +32,6 @@ data:
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
             namespace: {{ .Values.namespace1Path }}
-            incomingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $tag := .Values.namespace2Tags }}
-                - {{ $tag | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $tag := .Values.namespace2Tags }}
-                - {{ $tag | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             {{- range $index, $tag := .Values.namespace1Tags }}
             {{- if eq $index 0 }}
@@ -58,28 +40,28 @@ data:
               - {{ $tag | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $tag := .Values.namespace2Tags }}
+                - {{ $tag | quote }}
+              {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $tag := .Values.namespace2Tags }}
+                - {{ $tag | quote }}
+              {{- end }}
           - name: inter-namespace-second
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
             namespace: {{ .Values.namespace2Path }}
-            incomingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $tag := .Values.namespace1Tags }}
-                - {{ $tag | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $tag := .Values.namespace1Tags }}
-                - {{ $tag | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             {{- range $index, $tag := .Values.namespace2Tags }}
             {{- if eq $index 0 }}
@@ -88,6 +70,24 @@ data:
               - {{ $tag | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $tag := .Values.namespace1Tags }}
+                - {{ $tag | quote }}
+              {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $tag := .Values.namespace1Tags }}
+                - {{ $tag | quote }}
+              {{- end }}
           `}}
 
       steps:

--- a/policy-suggest-intra-group-namespaces.yaml
+++ b/policy-suggest-intra-group-namespaces.yaml
@@ -29,27 +29,27 @@ data:
           - name: auto-secure_intra-vm_groups
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             - - $type=Host
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
         `}}

--- a/policy-suggest-intra-k8s-namespaces.yaml
+++ b/policy-suggest-intra-k8s-namespaces.yaml
@@ -29,24 +29,6 @@ data:
           - name: auto-secure_intra-k8s_namespaces
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -55,4 +37,22 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
         `}}

--- a/policy-suggest-k8s-api-server.yaml
+++ b/policy-suggest-k8s-api-server.yaml
@@ -40,23 +40,23 @@ data:
           - name: "Allow incoming and outgoing to kube-api server"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=k8s-api-server"
-              protocolPorts:
-              - any
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=k8s-api-server"
-              protocolPorts:
-              - any
             subject:
             - - "$identity=processingunit"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "externalnetwork:name=k8s-api-server"
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "externalnetwork:name=k8s-api-server"
           `}}
 
       steps:

--- a/policy-suggest-kube-system-internal.yaml
+++ b/policy-suggest-kube-system-internal.yaml
@@ -29,24 +29,24 @@ data:
           - name: "Allow Kube System internal traffic"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-                - "@org:kubernetes=kube-system"
-              protocolPorts:
-              - "any"
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-                - "@org:kubernetes=kube-system"
-              protocolPorts:
-              - "any"
             subject:
             - - "$identity=processingunit"
               - "@org:kubernetes=kube-system"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - "any"
+              object:
+              - - "$identity=processingunit"
+                - "@org:kubernetes=kube-system"
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - "any"
+              object:
+              - - "$identity=processingunit"
+                - "@org:kubernetes=kube-system"
         `}}

--- a/policy-suggest-kube-system-to-host-pu.yaml
+++ b/policy-suggest-kube-system-to-host-pu.yaml
@@ -29,15 +29,6 @@ data:
           - name: "Allow kube system namespace to host PUs"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "app:host:type=kubernetes"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - "any"
             subject:
             - - "@org:kubernetes=kube-system"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
@@ -45,4 +36,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - "any"
+              object:
+              - - "app:host:type=kubernetes"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
         `}}

--- a/policy-suggest-kubelet.yaml
+++ b/policy-suggest-kubelet.yaml
@@ -40,12 +40,6 @@ data:
           - name: "Allow Kubelet"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=k8s_nodes"
-              protocolPorts:
-              - any
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -54,6 +48,12 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "externalnetwork:name=k8s_nodes"
           `}}
 
       steps:

--- a/policy-suggest-metadata-service.yaml
+++ b/policy-suggest-metadata-service.yaml
@@ -43,13 +43,6 @@ data:
           - name: metadata_service
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=metadata_service"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -58,6 +51,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=metadata_service"
           `}}
 
       steps:

--- a/policy-suggest-node-to-node.yaml
+++ b/policy-suggest-node-to-node.yaml
@@ -29,30 +29,30 @@ data:
           - name: "Allow Node to Node"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-                - "app:host:type=kubernetes"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "$identity=processingunit"
-                - "app:host:type=kubernetes"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             - - "$identity=processingunit"
               - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+                - "app:host:type=kubernetes"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "$identity=processingunit"
+                - "app:host:type=kubernetes"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
           `}}

--- a/policy-suggest-nodeport-addresses.yaml
+++ b/policy-suggest-nodeport-addresses.yaml
@@ -40,18 +40,18 @@ data:
           - name: nodeport_addresses
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=nodeport_addresses"
-              protocolPorts:
-              - tcp/30000:32767
             subject:
             - - "$identity=processingunit"
               - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/30000:32767
+              object:
+              - - "externalnetwork:name=nodeport_addresses"
           `}}
 
       steps:

--- a/policy-suggest-ntp.yaml
+++ b/policy-suggest-ntp.yaml
@@ -42,12 +42,6 @@ data:
           - name: ntp
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=ntp"
-              protocolPorts:
-              - udp/123
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +50,12 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - udp/123
+              object:
+              - - "externalnetwork:name=ntp"
           `}}
 
       steps:

--- a/policy-suggest-oracle-linux-update.yaml
+++ b/policy-suggest-oracle-linux-update.yaml
@@ -41,13 +41,6 @@ data:
           - name: oracle_linux_update
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=oracle_linux_update"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +49,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=oracle_linux_update"
           `}}
 
       steps:

--- a/policy-suggest-pc-api-server-and-konnectivity.yaml
+++ b/policy-suggest-pc-api-server-and-konnectivity.yaml
@@ -30,20 +30,6 @@ data:
           - name: "Allow Prisma Cloud API server and Konnectivity to kube system"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "@org:kubernetes=kube-system"
-              protocolPorts:
-              - "tcp/443"
-              - "tcp/8443"
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "@org:kubernetes=aporeto"
-              protocolPorts:
-              - "tcp/443"
-              - "tcp/8443"
             subject:
             - - "@org:kubernetes=kube-system"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
@@ -53,4 +39,18 @@ data:
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - "tcp/443"
+              - "tcp/8443"
+              object:
+              - - "@org:kubernetes=kube-system"
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - "tcp/443"
+              - "tcp/8443"
+              object:
+              - - "@org:kubernetes=aporeto"
         `}}

--- a/policy-suggest-pc-api-server-to-pc-console.yaml
+++ b/policy-suggest-pc-api-server-to-pc-console.yaml
@@ -39,15 +39,15 @@ data:
           - name: "Allow Prisma Cloud API server to Prisma Cloud console"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=Prisma Cloud Console"
-              protocolPorts:
-              - "tcp/443"
             subject:
             - - "@org:kubernetes=aporeto"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - "tcp/443"
+              object:
+              - - "externalnetwork:name=Prisma Cloud Console"
         `}}

--- a/policy-suggest-probes-from-nodes.yaml
+++ b/policy-suggest-probes-from-nodes.yaml
@@ -29,19 +29,19 @@ data:
           - name: "Allow Liveness/Readiness Probes from Nodes"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - $type=Docker
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             - - "$identity=processingunit"
               - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - $type=Docker
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
           `}}

--- a/policy-suggest-probes-to-pods.yaml
+++ b/policy-suggest-probes-to-pods.yaml
@@ -29,19 +29,19 @@ data:
           - name: "Allow Liveness/Readiness Probes to Pods"
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "app:host:type=kubernetes"
-              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
-                - {{ $orgmeta | quote }}
-              {{- end }}
-              protocolPorts:
-              - any
             subject:
             - - "$identity=processingunit"
               - $type=Docker
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - any
+              object:
+              - - "app:host:type=kubernetes"
+              {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
+                - {{ $orgmeta | quote }}
+              {{- end }}
           `}}

--- a/policy-suggest-rdp.yaml
+++ b/policy-suggest-rdp.yaml
@@ -42,12 +42,6 @@ data:
           - name: mgmt_rdp_network
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=mgmt_rdp_network"
-              protocolPorts:
-              - tcp/3389
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +50,12 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/3389
+              object:
+              - - "externalnetwork:name=mgmt_rdp_network"
         `}}
 
       steps:

--- a/policy-suggest-redhat-update.yaml
+++ b/policy-suggest-redhat-update.yaml
@@ -41,13 +41,6 @@ data:
           - name: redhat_update
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=redhat_update"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +49,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=redhat_update"
           `}}
 
       steps:

--- a/policy-suggest-ssh-to-nodes.yaml
+++ b/policy-suggest-ssh-to-nodes.yaml
@@ -40,18 +40,18 @@ data:
           - name: management_addresses
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=management_addresses"
-              protocolPorts:
-              - tcp/22
             subject:
             - - "$identity=processingunit"
               - "app:host:type=kubernetes"
             {{- range $_, $orgmeta := .Aporeto.OrganizationalMetadata }}
               - {{ $orgmeta | quote }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/22
+              object:
+              - - "externalnetwork:name=management_addresses"
           `}}
 
       steps:

--- a/policy-suggest-ssh.yaml
+++ b/policy-suggest-ssh.yaml
@@ -42,12 +42,6 @@ data:
           - name: mgmt_ssh_network
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            incomingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=mgmt_ssh_network"
-              protocolPorts:
-              - tcp/22
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +50,12 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            incomingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/22
+              object:
+              - - "externalnetwork:name=mgmt_ssh_network"
         `}}
 
       steps:

--- a/policy-suggest-suse-update.yaml
+++ b/policy-suggest-suse-update.yaml
@@ -41,13 +41,6 @@ data:
           - name: suse_update
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=suse_update"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +49,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=suse_update"
           `}}
 
       steps:

--- a/policy-suggest-ubuntu-update.yaml
+++ b/policy-suggest-ubuntu-update.yaml
@@ -41,13 +41,6 @@ data:
           - name: ubuntu_update
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=ubuntu_update"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +49,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=ubuntu_update"
           `}}
 
       steps:

--- a/policy-suggest-windows-update.yaml
+++ b/policy-suggest-windows-update.yaml
@@ -41,13 +41,6 @@ data:
           - name: windows_update
             description: "Ruleset automatically created by an Out of Box template."
             propagate: true
-            outgoingRules:
-            - action: Allow
-              object:
-              - - "externalnetwork:name=windows_update"
-              protocolPorts:
-              - tcp/80
-              - tcp/443
             subject:
             {{- range $index, $orgmeta := .Aporeto.OrganizationalMetadata }}
             {{- if eq $index 0 }}
@@ -56,6 +49,13 @@ data:
               - {{ $orgmeta | quote }}
             {{- end }}
             {{- end }}
+            outgoingRules:
+            - action: Allow
+              protocolPorts:
+              - tcp/80
+              - tcp/443
+              object:
+              - - "externalnetwork:name=windows_update"
           `}}
 
       steps:


### PR DESCRIPTION
In this PR we changed the order of elements for `rulesetpolicies` in the recipe yaml, so after they are rendered and displayed on UI, the order of the elements matches the order we display for policies on UI.

https://redlock.atlassian.net/browse/CNS-4385