### PR TITLE
Update: Listen to delete events for K8s edge cases

### DIFF
--- a/automations/automation-condition-enforcer-event-check-state.yaml
+++ b/automations/automation-condition-enforcer-event-check-state.yaml
@@ -52,6 +52,17 @@ data:
               shouldContinue = true
             }
             break;
+          case "delete":
+            if (currentState !== "Connected") {
+              return { continue: false };
+            }
+
+            // if Disconnected or Both, this is an event we want to report
+            if (params.enforcer_state !== "Connected") {
+              shouldContinue = true
+              currentState = "Deleted"
+            }
+            break;
         }
 
         return {

--- a/automations/automation-condition-pu-event-check-state.yaml
+++ b/automations/automation-condition-pu-event-check-state.yaml
@@ -52,6 +52,17 @@ data:
               shouldContinue = true
             }
             break;
+          case "delete":
+            if (currentState !== "Running") {
+              return { continue: false };
+            }
+
+            // if Stopped or Both, this is an event we want to report
+            if (params.pu_state !== "Running") {
+              shouldContinue = true
+              currentState = "Deleted"
+            }
+            break;
         }
 
         return {

--- a/automations/recipe-automation-enforcer-event.yaml
+++ b/automations/recipe-automation-enforcer-event.yaml
@@ -33,6 +33,7 @@ data:
               enforcer:
               - create
               - update
+              - delete
             condition: "@condition:enforcer_event_connection_state"
             actions:
             {{- range $_, $action := .Values.actions }}

--- a/automations/recipe-automation-pu-event.yaml
+++ b/automations/recipe-automation-pu-event.yaml
@@ -33,6 +33,7 @@ data:
               processingunit:
               - create
               - update
+              - delete
             condition: "@condition:pu_event_check_state"
             actions:
             {{- range $_, $action := .Values.actions }}


### PR DESCRIPTION
#### Description
During testing by Marcus Loo, he found out that certain scenarios for k8s do not cause PUs to transition from Running -> Stopped/Terminated. This likely also affects Enforcers on the edge case. This PR is meant to cover this scenarios if we want to track the Stopped/Disconnected states for either object types.